### PR TITLE
feat: Add edit_issue_comment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,10 +514,10 @@ The following sets of tools are available (all are on by default):
   - `repo`: Repository name (string, required)
 
 - **edit_issue_comment** - Edit issue comment
-  - `body`: New comment text content (string, required)
-  - `comment_id`: The ID of the comment to edit (number, required)
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
+  - `comment_id`: The ID of the comment to edit (number, required)
+  - `body`: New comment text content (string, required)
 
 - **add_sub_issue** - Add sub-issue
   - `issue_number`: The number of the parent issue (number, required)

--- a/README.md
+++ b/README.md
@@ -513,6 +513,12 @@ The following sets of tools are available (all are on by default):
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
 
+- **edit_issue_comment** - Edit issue comment
+  - `body`: New comment text content (string, required)
+  - `comment_id`: The ID of the comment to edit (number, required)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
+
 - **add_sub_issue** - Add sub-issue
   - `issue_number`: The number of the parent issue (number, required)
   - `owner`: Repository owner (string, required)

--- a/README.md
+++ b/README.md
@@ -513,12 +513,6 @@ The following sets of tools are available (all are on by default):
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
 
-- **edit_issue_comment** - Edit issue comment
-  - `owner`: Repository owner (string, required)
-  - `repo`: Repository name (string, required)
-  - `comment_id`: The ID of the comment to edit (number, required)
-  - `body`: New comment text content (string, required)
-
 - **add_sub_issue** - Add sub-issue
   - `issue_number`: The number of the parent issue (number, required)
   - `owner`: Repository owner (string, required)
@@ -539,6 +533,12 @@ The following sets of tools are available (all are on by default):
   - `owner`: Repository owner (string, required)
   - `repo`: Repository name (string, required)
   - `title`: Issue title (string, required)
+
+- **edit_issue_comment** - Edit issue comment
+  - `body`: New comment text content (string, required)
+  - `comment_id`: The ID of the comment to edit (number, required)
+  - `owner`: Repository owner (string, required)
+  - `repo`: Repository name (string, required)
 
 - **get_issue** - Get issue details
   - `issue_number`: The number of the issue (number, required)

--- a/pkg/github/__toolsnaps__/edit_issue_comment.snap
+++ b/pkg/github/__toolsnaps__/edit_issue_comment.snap
@@ -1,0 +1,35 @@
+{
+  "annotations": {
+    "title": "Edit issue comment",
+    "readOnlyHint": false
+  },
+  "description": "Edit an existing comment on a GitHub issue.",
+  "inputSchema": {
+    "properties": {
+      "body": {
+        "description": "New comment text content",
+        "type": "string"
+      },
+      "comment_id": {
+        "description": "The ID of the comment to edit",
+        "type": "number"
+      },
+      "owner": {
+        "description": "Repository owner",
+        "type": "string"
+      },
+      "repo": {
+        "description": "Repository name",
+        "type": "string"
+      }
+    },
+    "required": [
+      "owner",
+      "repo",
+      "comment_id",
+      "body"
+    ],
+    "type": "object"
+  },
+  "name": "edit_issue_comment"
+}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -381,27 +381,9 @@ func EditIssueComment(getClient GetClientFn, t translations.TranslationHelperFun
 			}
 			editedComment, resp, err := client.Issues.EditComment(ctx, owner, repo, commentID, comment)
 			if err != nil {
-				if resp != nil {
-					defer func() { _ = resp.Body.Close() }()
-					if resp.StatusCode != http.StatusOK {
-						body, err := io.ReadAll(resp.Body)
-						if err != nil {
-							return nil, fmt.Errorf("failed to read response body: %w", err)
-						}
-						return mcp.NewToolResultError(fmt.Sprintf("failed to edit comment: %s", string(body))), nil
-					}
-				}
-				return mcp.NewToolResultError(fmt.Sprintf("failed to edit comment: %v", err)), nil
+				return ghErrors.NewGitHubAPIErrorResponse(ctx, "failed to edit comment", resp, err), nil
 			}
 			defer func() { _ = resp.Body.Close() }()
-
-			if resp.StatusCode != http.StatusOK {
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
-				}
-				return mcp.NewToolResultError(fmt.Sprintf("failed to edit comment: %s", string(body))), nil
-			}
 
 			r, err := json.Marshal(editedComment)
 			if err != nil {

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -303,7 +303,7 @@ func Test_EditIssueComment(t *testing.T) {
 				"body":       "This is the edited comment",
 			},
 			expectError:    false,
-			expectedErrMsg: "failed to edit comment: {\"message\": \"Comment not found\"}",
+			expectedErrMsg: "failed to edit comment: PATCH",
 		},
 		{
 			name:         "missing body parameter",

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -303,7 +303,7 @@ func Test_EditIssueComment(t *testing.T) {
 				"body":       "This is the edited comment",
 			},
 			expectError:    false,
-			expectedErrMsg: "failed to edit comment: PATCH",
+			expectedErrMsg: "failed to edit comment:",
 		},
 		{
 			name:         "missing body parameter",

--- a/pkg/github/issues_test.go
+++ b/pkg/github/issues_test.go
@@ -236,6 +236,131 @@ func Test_AddIssueComment(t *testing.T) {
 	}
 }
 
+func Test_EditIssueComment(t *testing.T) {
+	// Verify tool definition once
+	mockClient := github.NewClient(nil)
+	tool, _ := EditIssueComment(stubGetClientFn(mockClient), translations.NullTranslationHelper)
+	require.NoError(t, toolsnaps.Test(tool.Name, tool))
+
+	assert.Equal(t, "edit_issue_comment", tool.Name)
+	assert.NotEmpty(t, tool.Description)
+	assert.Contains(t, tool.InputSchema.Properties, "owner")
+	assert.Contains(t, tool.InputSchema.Properties, "repo")
+	assert.Contains(t, tool.InputSchema.Properties, "comment_id")
+	assert.Contains(t, tool.InputSchema.Properties, "body")
+	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "comment_id", "body"})
+
+	// Setup mock comment for success case
+	mockEditedComment := &github.IssueComment{
+		ID:   github.Ptr(int64(123)),
+		Body: github.Ptr("This is the edited comment"),
+		User: &github.User{
+			Login: github.Ptr("testuser"),
+		},
+		HTMLURL: github.Ptr("https://github.com/owner/repo/issues/42#issuecomment-123"),
+	}
+
+	tests := []struct {
+		name            string
+		mockedClient    *http.Client
+		requestArgs     map[string]interface{}
+		expectError     bool
+		expectedComment *github.IssueComment
+		expectedErrMsg  string
+	}{
+		{
+			name: "successful comment edit",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+					mockResponse(t, http.StatusOK, mockEditedComment),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":      "owner",
+				"repo":       "repo",
+				"comment_id": float64(123),
+				"body":       "This is the edited comment",
+			},
+			expectError:     false,
+			expectedComment: mockEditedComment,
+		},
+		{
+			name: "comment edit fails",
+			mockedClient: mock.NewMockedHTTPClient(
+				mock.WithRequestMatchHandler(
+					mock.PatchReposIssuesCommentsByOwnerByRepoByCommentId,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message": "Comment not found"}`))
+					}),
+				),
+			),
+			requestArgs: map[string]interface{}{
+				"owner":      "owner",
+				"repo":       "repo",
+				"comment_id": float64(999),
+				"body":       "This is the edited comment",
+			},
+			expectError:    false,
+			expectedErrMsg: "failed to edit comment: {\"message\": \"Comment not found\"}",
+		},
+		{
+			name:         "missing body parameter",
+			mockedClient: mock.NewMockedHTTPClient(),
+			requestArgs: map[string]interface{}{
+				"owner":      "owner",
+				"repo":       "repo",
+				"comment_id": float64(123),
+			},
+			expectError:    false,
+			expectedErrMsg: "missing required parameter: body",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client with mock
+			client := github.NewClient(tc.mockedClient)
+			_, handler := EditIssueComment(stubGetClientFn(client), translations.NullTranslationHelper)
+
+			// Create call request
+			request := createMCPRequest(tc.requestArgs)
+
+			// Call handler
+			result, err := handler(context.Background(), request)
+
+			// Verify results
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				return
+			}
+
+			if tc.expectedErrMsg != "" {
+				require.NotNil(t, result)
+				textContent := getTextResult(t, result)
+				assert.Contains(t, textContent.Text, tc.expectedErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Parse the result and get the text content if no error
+			textContent := getTextResult(t, result)
+
+			// Parse JSON from result
+			var returnedComment github.IssueComment
+			err = json.Unmarshal([]byte(textContent.Text), &returnedComment)
+			require.NoError(t, err)
+			assert.Equal(t, *tc.expectedComment.ID, *returnedComment.ID)
+			assert.Equal(t, *tc.expectedComment.Body, *returnedComment.Body)
+			assert.Equal(t, *tc.expectedComment.User.Login, *returnedComment.User.Login)
+
+		})
+	}
+}
+
 func Test_SearchIssues(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)

--- a/pkg/github/tools.go
+++ b/pkg/github/tools.go
@@ -61,6 +61,7 @@ func DefaultToolsetGroup(readOnly bool, getClient GetClientFn, getGQLClient GetG
 		AddWriteTools(
 			toolsets.NewServerTool(CreateIssue(getClient, t)),
 			toolsets.NewServerTool(AddIssueComment(getClient, t)),
+			toolsets.NewServerTool(EditIssueComment(getClient, t)),
 			toolsets.NewServerTool(UpdateIssue(getClient, t)),
 			toolsets.NewServerTool(AssignCopilotToIssue(getGQLClient, t)),
 			toolsets.NewServerTool(AddSubIssue(getClient, t)),


### PR DESCRIPTION
Implements the edit_issue_comment tool to allow editing existing issue comments via the GitHub API. This addresses the feature request in issue #868.

Changes:
- Added EditIssueComment function in pkg/github/issues.go
- Registered the new tool in pkg/github/tools.go
- Added comprehensive tests for the new functionality
- Updated README documentation with the new tool

Fixes #868

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to edit existing issue comments, available in the Issues toolset (write tools).

* **Documentation**
  * Updated README to include the new edit_issue_comment tool with required fields: owner, repo, comment_id, and body.

* **Tests**
  * Added comprehensive tests covering successful edits, API error handling, and missing required parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->